### PR TITLE
add repository URL for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
     "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/bigpipe/enabled.git"
+  },
   "keywords": [
     "enabled",
     "debug",


### PR DESCRIPTION
Without this, it is that much harder for folks to find the repo page and submit PRs and/or issues.
