### PR TITLE
document proper use of wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ The returned `enabled` function accepts 2 arguments.
 #### Examples
 
 ```js
-process.env.DEBUG = 'foob';
+process.env.DEBUG = 'foo';
+enabled('foo') // true;
+enabled('bar') // false;
+
+// can use wildcards
+process.env.DEBUG = 'foob*';
 
 enabled('foobar') // true;
 enabled('barfoo') // false;


### PR DESCRIPTION
This PR documents proper use of wildcards.  The prior example in the README was incorrect:

``` js
process.env.DEBUG = 'foob';

enabled('foobar') // documented as true, but actually false;
enabled('barfoo') // false;
```

This PR corrects that example and adds an example of actual wildcard use.
