### PR TITLE
corrected dash behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ module.exports = function enabled(name, variables) {
     variable = variables[i].replace('*', '.*?');
 
     if ('-' === variable.charAt(0)) {
-      if (!(new RegExp('^'+ variable.substr(1) +'$')).test(name)) {
-        return true;
+      if ((new RegExp('^'+ variable.substr(1) +'$')).test(name)) {
+        return false;
       }
 
       continue;

--- a/test.js
+++ b/test.js
@@ -42,11 +42,13 @@ describe('enabled', function () {
   });
 
   it('can ignore loggers using a -', function () {
-    process.env.DEBUG = 'bigpipe,-primus,sack';
+    process.env.DEBUG = 'bigpipe,-primus,sack,-other';
 
     assume(enabled('bigpipe')).to.be.true();
     assume(enabled('sack')).to.be.true();
     assume(enabled('primus')).to.be.false();
+    assume(enabled('other')).to.be.false();
+    assume(enabled('unknown')).to.be.false();
   });
 
   it('supports multiple ranges', function () {


### PR DESCRIPTION
The current behavior for a toggle starting with a dash is extremely broken -- a toggle of `'-foo'` effectively turns on ALL loggers except for those named exactly `'foo'`!

An couple examples similar to that in test.js:

``` js
process.env.DEBUG = 'bigpipe,-primus,sack';

enabled('bigpipe')  // yields true, correct
enabled('sack')  // yields true, correct
enabled('primus')  // yields false, correct
enabled('other')  // yields true but should be false by default, incorrect
enabled('unknown')  // yields true but should be false by default, incorrect
```

``` js
process.env.DEBUG = 'bigpipe,-primus,sack,-other';

enabled('bigpipe')  // yields true, correct
enabled('sack')  // yields true, correct
enabled('primus')  // yields true due to the '-other' toggle, incorrect
enabled('other')  // yields true due to the '-primus' toggle, incorrect
enabled('unknown')  // yields true but should be false by default, incorrect
```

This is a major problem.

This PR fixes it so a negative toggle correctly forces a return of false, with an improved test to catch the issue and verify the fix.  When there are 2 conflicting rules (one that turns on a given toggle and one that would turn the same thing off), precedence is based on the order within the variable, earlier wins.
